### PR TITLE
Add timeout option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 julia = "1"
 JuliaWorkspaces = "1.1"
 JSON = "0.21"
-JSONRPC = "1.3"
+JSONRPC = "1.3.5"
 ProgressMeter = "1.7"
 
 [targets]


### PR DESCRIPTION
Requires https://github.com/julia-vscode/JSONRPC.jl/pull/72.

The timeout is per testitem execution in seconds.